### PR TITLE
Disable building v4l2 on Linux

### DIFF
--- a/rpm/qt6-qtmultimedia.spec
+++ b/rpm/qt6-qtmultimedia.spec
@@ -72,6 +72,7 @@ Requires: pkgconfig(libpulse-mainloop-glib)
 %cmake_qt6 \
   -DQT_FEATURE_alsa=OFF \
   -DQT_FEATURE_ffmpeg=ON \
+  -DQT_FEATURE_linux_v4l=OFF \
   -DQT_BUILD_EXAMPLES:BOOL=OFF \
   -DQT_INSTALL_EXAMPLES_SOURCES=OFF
 


### PR DESCRIPTION
Should get rid of this:

```
src/plugins/multimedia/ffmpeg/qv4l2cameradevices.cpp:80:31:
error: use of undeclared identifier 'V4L2_CAP_META_CAPTURE'
         if (cap.device_caps & V4L2_CAP_META_CAPTURE)
                               ^
```
